### PR TITLE
Improve download performance

### DIFF
--- a/TownSuite.CodeSigning.Client/SigningClient.cs
+++ b/TownSuite.CodeSigning.Client/SigningClient.cs
@@ -42,7 +42,7 @@ namespace TownSuite.CodeSigning.Client
 
 
                     var request = new HttpRequestMessage(HttpMethod.Post, url);
-                    using var fs = File.OpenRead(filepath);
+                    await using var fs = File.OpenRead(filepath);
                     request.Content = new StreamContent(fs);
                     Console.WriteLine($"Uploading file: {filepath}");
                     var response = await _client.SendAsync(request);
@@ -124,10 +124,9 @@ namespace TownSuite.CodeSigning.Client
                 var response = await _client.GetAsync(pollUrl);
                 if (response.IsSuccessStatusCode)
                 {
-                    using var resultStream = await response.Content.ReadAsStreamAsync();
-                    using var memoryStream = new MemoryStream();
-                    await resultStream.CopyToAsync(memoryStream);
-                    await File.WriteAllBytesAsync(file.FilePath, memoryStream.ToArray());
+                    await using var resultStream = await response.Content.ReadAsStreamAsync();
+                    await using var fileStream = File.OpenWrite(file.FilePath);
+                    await resultStream.CopyToAsync(fileStream);
                     goodFiles.Add(file);
                     Console.WriteLine($"Signed file: {file.FilePath}");
                 }

--- a/TownSuite.CodeSigning.Service/BatchedSigning.cs
+++ b/TownSuite.CodeSigning.Service/BatchedSigning.cs
@@ -79,9 +79,9 @@ namespace TownSuite.CodeSigning.Service
 
             if (System.IO.File.Exists(System.IO.Path.Combine(workingFolder.FullName, $"{id}.signed")))
             {
-                var file = await File.ReadAllBytesAsync(System.IO.Path.Combine(workingFolder.FullName, $"{id}.workingfile"));
-                CleanupDir(workingFolder, logger);
-                return Results.File(file);
+                var workingFile = System.IO.Path.Combine(workingFolder.FullName, $"{id}.workingfile");
+                var fileStream = new TempFileStream(workingFile, workingFolder);
+                return Results.Stream(fileStream);
             }
 
             if (System.IO.File.Exists(System.IO.Path.Combine(workingFolder.FullName, $"{id}.error")))
@@ -91,7 +91,6 @@ namespace TownSuite.CodeSigning.Service
 
             return Results.Problem(title: "Not Signed", detail: "The file has not been signed yet", statusCode: 425);
         }
-
 
         static void CleanupDir(DirectoryInfo dir, ILogger logger)
         {
@@ -104,7 +103,5 @@ namespace TownSuite.CodeSigning.Service
                 logger.LogError(ex, $"failed to cleanup dir {dir}");
             }
         }
-
     }
-
 }

--- a/TownSuite.CodeSigning.Service/TempFileStream.cs
+++ b/TownSuite.CodeSigning.Service/TempFileStream.cs
@@ -1,0 +1,25 @@
+﻿namespace TownSuite.CodeSigning.Service
+{
+    public class TempFileStream: FileStream
+    {
+        private readonly DirectoryInfo _dir;
+
+        public TempFileStream(string workingFile, DirectoryInfo directoryToRemove)
+            : base(workingFile, FileMode.Open, FileAccess.Read, FileShare.None, 4096, FileOptions.DeleteOnClose)
+        {
+            _dir = directoryToRemove;
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await base.DisposeAsync();
+            _dir.Delete(true);
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+            _dir.Delete(true);
+        }
+    }
+}

--- a/TownSuite.CodeSigning.Tests/BatchedSigningTest.cs
+++ b/TownSuite.CodeSigning.Tests/BatchedSigningTest.cs
@@ -44,7 +44,14 @@ namespace TownSuite.CodeSigning.Tests
             {
                 var dr = await BatchedSigning.Get(id, NSubstitute.Substitute.For<ILogger>());
 
-                if (dr is Microsoft.AspNetCore.Http.HttpResults.FileContentHttpResult file)
+                if (dr is Microsoft.AspNetCore.Http.HttpResults.FileStreamHttpResult streamResult)
+                {
+                    doLoop = false;
+                    await using var resultStream = streamResult.FileStream;
+                    await using var file = File.OpenWrite(assemblyPath);
+                    resultStream.CopyTo(file);
+                }
+                else if (dr is Microsoft.AspNetCore.Http.HttpResults.FileContentHttpResult file)
                 {
                     doLoop = false;
                     await System.IO.File.WriteAllBytesAsync(assemblyPath, file.FileContents.ToArray());


### PR DESCRIPTION
## Description
Improve performance when downloading the signed file(s) by reducing how often the streams are copied. See the commits for more details.

## Testing
Manually tested using the certificate generated by Certs.cs from the test project. The signtoolpath and signtooloptions found in OneTimeUnitTestSetup were used for the appsettings for the locally running service.

![image](https://github.com/user-attachments/assets/ce1ad192-aa36-4f96-964c-15d71459f549)

I also tested it using multiple dlls at once.

Both automated tests pass.