### PR TITLE
Add configurable semaphore limit based on CPU cores

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,13 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
-    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
+    <Version>2.0.1</Version>
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Company>TownSuite Municipal Software Inc.</Company>
     <Product>TownSuite Code Signing</Product>
-    <Copyright>Copyright © TownSuite Municipal Software Inc. 2024</Copyright>
+    <Copyright>Copyright © TownSuite Municipal Software Inc. 2025</Copyright>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/TownSuite.CodeSigning.Service/BatchedSigning.cs
+++ b/TownSuite.CodeSigning.Service/BatchedSigning.cs
@@ -34,7 +34,7 @@ namespace TownSuite.CodeSigning.Service
                     try
                     {
                         using var signer = new Signer(settings, logger);
-                        await Queuing.semaphore.WaitAsync();
+                        await Queuing.Semaphore.WaitAsync();
                         var results = await signer.SignAsync(workingFilePath);
 
                         if (results.IsSigned)
@@ -54,7 +54,7 @@ namespace TownSuite.CodeSigning.Service
                     }
                     finally
                     {
-                        Queuing.semaphore.Release();
+                        Queuing.Semaphore.Release();
                     }
                 });
 

--- a/TownSuite.CodeSigning.Service/Program.cs
+++ b/TownSuite.CodeSigning.Service/Program.cs
@@ -51,6 +51,8 @@ LogSetup(builder);
 
 var app = builder.Build();
 
+Queuing.SetSemaphore(builder.Configuration.GetSection("Settings").Get<Settings>());
+
 // Configure the HTTP request pipeline.
 
 app.UseHttpsRedirection();

--- a/TownSuite.CodeSigning.Service/Program.cs
+++ b/TownSuite.CodeSigning.Service/Program.cs
@@ -80,7 +80,7 @@ app.MapPost("/sign", async (HttpRequest request, Settings settings, ILogger logg
         }
 
         using var signer = new Signer(settings, logger);
-        await Queuing.semaphore.WaitAsync();
+        await Queuing.Semaphore.WaitAsync();
         var results = await signer.SignAsync(workingFilePath.FullName);
 
         if (results.IsSigned)
@@ -98,7 +98,7 @@ app.MapPost("/sign", async (HttpRequest request, Settings settings, ILogger logg
     }
     finally
     {
-        Queuing.semaphore.Release();
+        Queuing.Semaphore.Release();
         Cleanup(workingFilePath, logger);
     }
 });

--- a/TownSuite.CodeSigning.Service/Queuing.cs
+++ b/TownSuite.CodeSigning.Service/Queuing.cs
@@ -1,6 +1,13 @@
-﻿static class Queuing
+﻿namespace TownSuite.CodeSigning.Service
 {
-    // Allows concurrent operations up to the number of CPU cores
-    public static SemaphoreSlim semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+    static class Queuing
+    {
+        public static void SetSemaphore(Settings settings)
+        {
+            // Initialize the semaphore with the limit set in settings
+            semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount * settings.SemaphoreSlimProcessPerCpuLimit);
+        }
+        // Allows concurrent operations up to the number of CPU cores
+        public static SemaphoreSlim semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+    }
 }
-

--- a/TownSuite.CodeSigning.Service/Queuing.cs
+++ b/TownSuite.CodeSigning.Service/Queuing.cs
@@ -4,8 +4,15 @@
     {
         public static void SetSemaphore(Settings settings)
         {
-            // Initialize the semaphore with the limit set in settings
-            semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount * settings.SemaphoreSlimProcessPerCpuLimit);
+            // Validate that the configured limit is greater than 0
+            if (settings.SemaphoreSlimProcessPerCpuLimit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(settings.SemaphoreSlimProcessPerCpuLimit), "SemaphoreSlimProcessPerCpuLimit must be greater than 0.");
+            }
+
+            int count = Environment.ProcessorCount * settings.SemaphoreSlimProcessPerCpuLimit;
+            // Initialize the semaphore with both initialCount and maxCount set to the calculated value
+            semaphore = new SemaphoreSlim(count, count);
         }
         // Allows concurrent operations up to the number of CPU cores
         public static SemaphoreSlim semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);

--- a/TownSuite.CodeSigning.Service/Queuing.cs
+++ b/TownSuite.CodeSigning.Service/Queuing.cs
@@ -1,4 +1,6 @@
-﻿namespace TownSuite.CodeSigning.Service
+﻿using System.Threading;
+
+namespace TownSuite.CodeSigning.Service
 {
     static class Queuing
     {
@@ -12,9 +14,19 @@
 
             int count = Environment.ProcessorCount * settings.SemaphoreSlimProcessPerCpuLimit;
             // Initialize the semaphore with both initialCount and maxCount set to the calculated value
-            semaphore = new SemaphoreSlim(count, count);
+            _semaphore = new SemaphoreSlim(count, count);
         }
         // Allows concurrent operations up to the number of CPU cores
-        public static SemaphoreSlim semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+        private static SemaphoreSlim? _semaphore;
+
+        public static SemaphoreSlim Semaphore
+        {
+            get
+            {
+                if (_semaphore == null)
+                    throw new InvalidOperationException("Semaphore not initialized. Call SetSemaphore first.");
+                return _semaphore;
+            }
+        }
     }
 }

--- a/TownSuite.CodeSigning.Service/Settings.cs
+++ b/TownSuite.CodeSigning.Service/Settings.cs
@@ -6,5 +6,6 @@
         public string SignToolOptions { get; init; }
         public int SigntoolTimeoutInMs { get; init; }
         public long MaxRequestBodySize { get; init; }
+        public int SemaphoreSlimProcessPerCpuLimit { get; init; }
     }
 }


### PR DESCRIPTION
Introduce `SemaphoreSlimProcessPerCpuLimit` in the `Settings` class to customize semaphore behavior. Implement `SetSemaphore` method in the `Queuing` class to initialize the semaphore with this new limit. Update `Program.cs` to call `SetSemaphore` during application startup for dynamic configuration.