### PR TITLE
Add proper signtool batch processing and cleanup features

### DIFF
--- a/TownSuite.CodeSigning.Client/SigningClient.cs
+++ b/TownSuite.CodeSigning.Client/SigningClient.cs
@@ -26,8 +26,11 @@ namespace TownSuite.CodeSigning.Client
         {
             var failedUploads = new List<(string FailedFile, string Message)>();
 
+            var batchId = Guid.NewGuid().ToString();
+
             var urk = new Uri(_url);
             string url = $"{urk.Scheme}://{urk.Host}:{urk.Port}/sign/batch";
+            string lastFile = filepaths.Last();
             foreach (string filepath in filepaths)
             {
                 bool failures = false;
@@ -40,8 +43,14 @@ namespace TownSuite.CodeSigning.Client
                         continue;
                     }
 
-
                     var request = new HttpRequestMessage(HttpMethod.Post, url);
+                    request.Headers.Add("X-BatchId", batchId);
+                    // if this is the last file add the X-BatchReady header
+                    if (lastFile == filepath)
+                    {
+                        request.Headers.Add("X-BatchReady", "true");
+                    }
+
                     await using var fs = File.OpenRead(filepath);
                     request.Content = new StreamContent(fs);
                     Console.WriteLine($"Uploading file: {filepath}");

--- a/TownSuite.CodeSigning.Service/Certs.cs
+++ b/TownSuite.CodeSigning.Service/Certs.cs
@@ -6,11 +6,11 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TownSuite.CodeSigning.Tests
+namespace TownSuite.CodeSigning.Service
 {
-    static internal class Certs
+    static public class Certs
     {
-        public static void CreateTestCert(string savePath = "testcert.pfx", string password = "password")
+        public static void CreateTestCert(string savePath, string password)
         {
             // Define the certificate subject name
             string subjectName = "CN=TestCertificate";

--- a/TownSuite.CodeSigning.Service/CleanerService.cs
+++ b/TownSuite.CodeSigning.Service/CleanerService.cs
@@ -1,0 +1,43 @@
+﻿
+using System.Runtime;
+using System.Threading;
+
+namespace TownSuite.CodeSigning.Service
+{
+    public class CleanerService : BackgroundService
+    {
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                CleanupOldFolders();
+                await Task.Delay(TimeSpan.FromMinutes(10));
+            }
+        }
+
+        static void CleanupOldFolders()
+        {
+            // if a working folder is more than 1 hour old delete it
+            var baseFolder = new DirectoryInfo(BatchedSigning.GetTempFolder());
+            var folders = baseFolder.GetDirectories();
+            DateTime currentTime = DateTime.Now;
+            foreach (var folder in folders)
+            {
+                TimeSpan age = currentTime - folder.CreationTime;
+                if (age.TotalHours > 1)
+                {
+                    try
+                    {
+                        folder.Delete(true);
+                    }
+                    catch (Exception)
+                    {
+                        Console.Error.WriteLine($"Failed to delete folder {folder.FullName} and will try again later");
+                    }
+
+                }
+            }
+
+        }
+    }
+}

--- a/TownSuite.CodeSigning.Service/Queuing.cs
+++ b/TownSuite.CodeSigning.Service/Queuing.cs
@@ -2,7 +2,7 @@
 
 namespace TownSuite.CodeSigning.Service
 {
-    static class Queuing
+    public static class Queuing
     {
         public static void SetSemaphore(Settings settings)
         {

--- a/TownSuite.CodeSigning.Service/Signer.cs
+++ b/TownSuite.CodeSigning.Service/Signer.cs
@@ -29,12 +29,25 @@ namespace TownSuite.CodeSigning.Service
             p.Dispose();
         }
 
-        public async Task<(bool IsSigned, string Message)> SignAsync(string currentfile)
+        public async Task<(bool IsSigned, string Message)> SignAsync(string workingDir, string[] files)
         {
             p = new System.Diagnostics.Process();
             p.StartInfo.FileName = _settings.SignToolPath;
 
-            p.StartInfo.Arguments = _settings.SignToolOptions.Replace("{FilePath}", currentfile);
+            if (files.Length == 1)
+            {
+                p.StartInfo.Arguments = _settings.SignToolOptions
+                    .Replace("{FilePath}", files[0])
+                    .Replace("{BaseDirectory}", AppContext.BaseDirectory);
+            }
+            else
+            {
+                p.StartInfo.Arguments = _settings.SignToolOptions
+                    .Replace("\"{FilePath}\"", string.Join(" ", files))
+                    .Replace("{BaseDirectory}", AppContext.BaseDirectory);
+            }
+
+            p.StartInfo.WorkingDirectory = workingDir;
             p.StartInfo.UseShellExecute = false;
             p.StartInfo.ErrorDialog = false;
             p.StartInfo.CreateNoWindow = true;

--- a/TownSuite.CodeSigning.Service/TempFileStream.cs
+++ b/TownSuite.CodeSigning.Service/TempFileStream.cs
@@ -3,10 +3,11 @@
     public class TempFileStream: FileStream
     {
         private readonly DirectoryInfo _dir;
-
+        private readonly string _workingFile;
         public TempFileStream(string workingFile, DirectoryInfo directoryToRemove)
             : base(workingFile, FileMode.Open, FileAccess.Read, FileShare.None, 4096, FileOptions.DeleteOnClose)
         {
+            _workingFile = workingFile;
             _dir = directoryToRemove;
         }
 
@@ -19,7 +20,8 @@
         public new void Dispose()
         {
             base.Dispose();
-            _dir.Delete(true);
+            System.IO.File.Delete(_workingFile);
+            _dir?.Delete(true);
         }
     }
 }

--- a/TownSuite.CodeSigning.Service/appsettings.json
+++ b/TownSuite.CodeSigning.Service/appsettings.json
@@ -7,11 +7,11 @@
   },
   "AllowedHosts": "*",
   "Settings": {
-    "SignToolPath": "signtool.exe",
-    "SignToolOptions": "sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /n \"CERT NAME HERE\" \"{FilePath}\"",
+    "SignToolPath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages\\microsoft.windows.sdk.buildtools\\10.0.26100.1742\\bin\\10.0.26100.0\\x86\\signtool.exe",
+    "SignToolOptions": "sign /tr \"http://timestamp.digicert.com\" /td SHA256 /fd SHA256 /f \"{BaseDirectory}testcert.pfx\" /p \"password\" /v \"{FilePath}\"",
     "SigntoolTimeoutInMs": 15000,
     "MaxRequestBodySize": 200000000,
-    "SemaphoreSlimProcessPerCpuLimit":  1
+    "SemaphoreSlimProcessPerCpuLimit": 1
   },
   // If the JWT section is missing or the secret is not set then JWT validation will be disabled.
   "JWT": {

--- a/TownSuite.CodeSigning.Tests/BatchedSigningTest.cs
+++ b/TownSuite.CodeSigning.Tests/BatchedSigningTest.cs
@@ -13,27 +13,46 @@ namespace TownSuite.CodeSigning.Tests
     [TestFixture]
     public class BatachedSigningTest
     {
-        [Test]
-        public async Task Test1()
+
+        public static object[] TestFiles =
+        {
+            new string[]{"srcfile1.dll"},
+            new string[]{"srcfile2.dll", "srcfile3.dll"}
+        };
+
+        [Test, TestCaseSource(nameof(TestFiles))]
+        public async Task Test1(string[] srcFiles)
         {
             // Arrange
-            var srcAssemblyPath = System.IO.Path.Combine(AppContext.BaseDirectory, "test.dll");
-            var assemblyPath = System.IO.Path.Combine(AppContext.BaseDirectory, "test_batched.dll");
+            var srcAssemblyPath = Path.Combine(AppContext.BaseDirectory, "test.dll");
+
+
+            var ids = new List<string>();
+            var results = new List<Microsoft.AspNetCore.Http.HttpResults.Ok<string>>();
             var settings = OneTimeUnitTestSetup.SignToolSettings;
 
-            // Act upload
+            foreach (var filepath in srcFiles)
+            {
+                File.Copy("test.dll", Path.Combine(AppContext.BaseDirectory, filepath), true);
+                using var fs = new FileStream(srcAssemblyPath, FileMode.Open, FileAccess.Read);
+                var ur = await BatchedSigning.Sign(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(), fs, settings, NSubstitute.Substitute.For<ILogger>());
+                var uploadResult = ur as Microsoft.AspNetCore.Http.HttpResults.Ok<string>;
+                results.Add(uploadResult);
+                string id = uploadResult?.Value?.Replace("\"", "");
+                ids.Add(id);
+            }
 
-            using var fs = new FileStream(srcAssemblyPath, FileMode.Open, FileAccess.Read);
-            var ur = await BatchedSigning.Sign(fs, settings, NSubstitute.Substitute.For<ILogger>());
-            var uploadResult = ur as Microsoft.AspNetCore.Http.HttpResults.Ok<string>;
-            string id = uploadResult?.Value?.Replace("\"", "");
+
 
             // Assert
 
             Assert.Multiple(() =>
             {
-                Assert.That(uploadResult, Is.Not.Null);
-                Assert.That(uploadResult.StatusCode, Is.EqualTo(200));
+                foreach (var uploadResult in results)
+                {
+                    Assert.That(uploadResult, Is.Not.Null);
+                    Assert.That(uploadResult.StatusCode, Is.EqualTo(200));
+                }
             });
 
             // Act download
@@ -42,36 +61,45 @@ namespace TownSuite.CodeSigning.Tests
             int count = 0;
             while (doLoop && count <20)
             {
-                var dr = await BatchedSigning.Get(id, NSubstitute.Substitute.For<ILogger>());
+                foreach (var id in ids)
+                {
+                    string assemblyPath = id;
+                    var dr = await BatchedSigning.Get(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(), id, NSubstitute.Substitute.For<ILogger>());
 
-                if (dr is Microsoft.AspNetCore.Http.HttpResults.FileStreamHttpResult streamResult)
-                {
-                    doLoop = false;
-                    await using var resultStream = streamResult.FileStream;
-                    await using var file = File.OpenWrite(assemblyPath);
-                    resultStream.CopyTo(file);
-                }
-                else if (dr is Microsoft.AspNetCore.Http.HttpResults.FileContentHttpResult file)
-                {
-                    doLoop = false;
-                    await System.IO.File.WriteAllBytesAsync(assemblyPath, file.FileContents.ToArray());
-                }
-                else if (dr is Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult phr)
-                {
-                    if (phr.StatusCode == 425)
-                    {
-                        await Task.Delay(1000);
-                    }
-                    else
+                    if (dr is Microsoft.AspNetCore.Http.HttpResults.FileStreamHttpResult streamResult)
                     {
                         doLoop = false;
-                        Assert.Fail();
+                        await using var resultStream = streamResult.FileStream;
+                        await using var file = File.OpenWrite(assemblyPath);
+                        resultStream.CopyTo(file);
                     }
-                }
+                    else if (dr is Microsoft.AspNetCore.Http.HttpResults.FileContentHttpResult file)
+                    {
+                        doLoop = false;
+                        await File.WriteAllBytesAsync(assemblyPath, file.FileContents.ToArray());
+                    }
+                    else if (dr is Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult phr)
+                    {
+                        if (phr.StatusCode == 425)
+                        {
+                            await Task.Delay(1000);
+                        }
+                        else
+                        {
+                            doLoop = false;
+                            Assert.Fail();
+                        }
+                    }
 
-                count++;
+                    count++;
+                }
             }
-            Assert.IsTrue(Certs.ValidateDigitalSignature(assemblyPath, OneTimeUnitTestSetup.certPath, OneTimeUnitTestSetup.password));
+
+            foreach (var id in ids)
+            {
+                Assert.IsTrue(Certs.ValidateDigitalSignature(id, OneTimeUnitTestSetup.certPath, OneTimeUnitTestSetup.password));
+                File.Delete(id);
+            }
 
         }
     }

--- a/TownSuite.CodeSigning.Tests/OneTimeUnitTestSetup.cs
+++ b/TownSuite.CodeSigning.Tests/OneTimeUnitTestSetup.cs
@@ -15,14 +15,17 @@ namespace TownSuite.CodeSigning.Tests
         [OneTimeSetUp]
         public void Setup()
         {
-            Certs.CreateTestCert(certPath);
+            Certs.CreateTestCert(certPath, password);
             SignToolSettings = new Settings()
             {
                 MaxRequestBodySize = 1000000,
-                SignToolOptions = "sign /fd SHA256 /f \"testcert.pfx\" /p \"password\" /t \"http://timestamp.digicert.com\" /v \"{FilePath}\"",
+                SignToolOptions = "sign /fd SHA256 /f \"{BaseDirectory}testcert.pfx\" /p \"password\" /t \"http://timestamp.digicert.com\" /v \"{FilePath}\"",
                 SignToolPath = SignToolPath,
-                SigntoolTimeoutInMs = 10000
+                SigntoolTimeoutInMs = 10000,
+                SemaphoreSlimProcessPerCpuLimit=1
             };
+
+            CodeSigning.Service.Queuing.SetSemaphore(SignToolSettings);
         }
 
         [OneTimeTearDown]

--- a/TownSuite.CodeSigning.Tests/SignerTest.cs
+++ b/TownSuite.CodeSigning.Tests/SignerTest.cs
@@ -22,7 +22,7 @@ namespace TownSuite.CodeSigning.Tests
             var signer = new Signer(settings, NSubstitute.Substitute.For<ILogger>());
             // Act
             System.IO.File.Copy(srcAssemblyPath, assemblyPath, true);
-            var result = await signer.SignAsync(assemblyPath);
+            var result = await signer.SignAsync(AppContext.BaseDirectory, [assemblyPath]);
             // Assert
 
             Assert.Multiple(() =>


### PR DESCRIPTION
- Enhanced `UploadFiles` in `SigningClient.cs` to support batch uploads with new headers for batch processing.
- Updated `Sign` method in `BatchedSigning.cs` to accept headers and introduced methods for batch file processing.
- Added `CleanerService` to periodically remove old working folders.
- Modified `Program.cs` to create a test certificate based on settings and updated batch signing endpoint.
- Updated `SignAsync` in `Signer.cs` to handle multiple files for signing.
- Adjusted `TempFileStream` to delete working files upon disposal.
- Changed `appsettings.json` to update sign tool path and signing options.
- Updated test files and `OneTimeUnitTestSetup` to accommodate new batch signing functionality.