### PR TITLE
Add file existence check in ProcessFiles method

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>2.0.2</AssemblyVersion>
-    <FileVersion>2.0.2</FileVersion>
-    <Version>2.0.2</Version>
+    <AssemblyVersion>2.0.3</AssemblyVersion>
+    <FileVersion>2.0.3</FileVersion>
+    <Version>2.0.3</Version>
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Company>TownSuite Municipal Software Inc.</Company>

--- a/TownSuite.CodeSigning.Client/Program.cs
+++ b/TownSuite.CodeSigning.Client/Program.cs
@@ -168,6 +168,12 @@ async Task<bool> ProcessFiles(string[] filepaths, string url, bool quickFail, bo
 {
     List<string> files = FileHelpers.CreateFileList(filepaths, folder);
 
+    if (files.Count == 0)
+    {
+        Console.WriteLine("No files found to sign.");
+        return false;
+    }
+
     var signer = new SigningClient(client, url);
 
     bool signingServiceIsOnline = await signer.HealthCheck();


### PR DESCRIPTION
Introduce a validation to ensure the files list is not empty. If no files are found, a message is displayed to the user, and the method returns false to prevent further processing.