### PR TITLE
Update to .NET 10.0 and adjust build workflows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Build
         run: chmod +x ./build_linux.sh && ./build_linux.sh
       - name: Archive artifacts
@@ -24,15 +24,15 @@ jobs:
         with:
           name: linux-x64
           path: |
-            TownSuite.CodeSigning.Service/bin/Release/net8.0
-            TownSuite.CodeSigning.Client/bin/Release/net8.0/*
+            TownSuite.CodeSigning.Service/bin/Release/net10.0
+            TownSuite.CodeSigning.Client/bin/Release/net10.0/*
           retention-days: 1
       - name: Archive Self Contained Linux Client
         uses: actions/upload-artifact@v6
         with:
           name: linux-x64-client
           path: |
-            TownSuite.CodeSigning.Client/bin/Release/net8.0/linux-x64/publish/
+            TownSuite.CodeSigning.Client/bin/Release/net10.0/linux-x64/publish/
           retention-days: 1
       - name: Archive Self Contained Debian Linux Client
         uses: actions/upload-artifact@v6
@@ -49,7 +49,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Build
         run: ./build_windows.ps1
       - name: Archive artifacts
@@ -57,13 +57,13 @@ jobs:
         with:
           name: win-x64
           path: |
-            TownSuite.CodeSigning.Service/bin/Release/net8.0
-            TownSuite.CodeSigning.Client/bin/Release/net8.0/*
+            TownSuite.CodeSigning.Service/bin/Release/net10.0
+            TownSuite.CodeSigning.Client/bin/Release/net10.0/*
           retention-days: 1
       - name: Archive Self Contained Windows Client
         uses: actions/upload-artifact@v6
         with:
           name: win-x64-client
           path: |
-            TownSuite.CodeSigning.Client/bin/Release/net8.0/win-x64/publish/
+            TownSuite.CodeSigning.Client/bin/Release/net10.0/win-x64/publish/
           retention-days: 1

--- a/TownSuite.CodeSigning.Client/TownSuite.CodeSigning.Client.csproj
+++ b/TownSuite.CodeSigning.Client/TownSuite.CodeSigning.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/TownSuite.CodeSigning.ClientTests/TownSuite.CodeSigning.ClientTests.csproj
+++ b/TownSuite.CodeSigning.ClientTests/TownSuite.CodeSigning.ClientTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/TownSuite.CodeSigning.Service/TownSuite.CodeSigning.Service.csproj
+++ b/TownSuite.CodeSigning.Service/TownSuite.CodeSigning.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>844a7446-2fec-4ebd-a20d-c268fd65df52</UserSecretsId>

--- a/TownSuite.CodeSigning.Tests/TownSuite.CodeSigning.Tests.csproj
+++ b/TownSuite.CodeSigning.Tests/TownSuite.CodeSigning.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -8,7 +8,7 @@ dotnet publish TownSuite.CodeSigning.Client -c Release -r linux-x64 -p:PublishRe
 
 rm -rf /build/linux
 mkdir -p build/linux/opt/townsuite/codesigning/client
-cp -r TownSuite.CodeSigning.Client/bin/Release/net8.0/linux-x64/publish/* build/linux/opt/townsuite/codesigning/client/
+cp -r TownSuite.CodeSigning.Client/bin/Release/net10.0/linux-x64/publish/* build/linux/opt/townsuite/codesigning/client/
 mkdir -p build/linux/usr/bin
 cp -r townsuite-code-signing-client build/linux/usr/bin/townsuite-code-signing-client
 chmod +x build/linux/usr/bin/townsuite-code-signing-client


### PR DESCRIPTION
Upgraded all projects to target .NET 10.0 instead of 8.0. Updated GitHub Actions workflows to use .NET 10.0.x for both Linux and Windows, and modified artifact paths to include net10.0 outputs. Updated build_linux.sh to handle net10.0 publish directories.