### PR TITLE
Fix client side signature verification on Linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Linux Build') {
+                stage('Linux Build and Code Signing') {
                     agent { label townsuite_automation2.get_ubuntu_label() }
                     steps {
                         script {
@@ -92,11 +92,55 @@ pipeline {
 
                         sh '''
                         apt update
-                        apt install -y zip ruby
+                        apt install -y zip ruby osslsigncode
                         chmod +x ./build_linux.sh
                         ./build_linux.sh
                         '''
-                    
+
+                        // code signing with the linux client build; the client verifies each
+                        // downloaded file client-side (cross-platform PE Authenticode check)
+                        // and exits non-zero if verification fails
+                        withCredentials([
+                            string(credentialsId: 'codesigning_service_url', variable: 'CODESIGNING_SERVICE_URL'),
+                            string(credentialsId: 'codesigning_auth_key', variable: 'CODESIGNING_AUTH_KEY')
+                        ]) {
+                            // diagnose DNS/connectivity before signing attempt
+                            sh '''
+                            HOST=$(echo "$CODESIGNING_SERVICE_URL" | sed -E 's|^[a-z]+://([^:/]+).*|\\1|')
+                            echo "Resolving $HOST..."
+                            getent hosts "$HOST" || true
+                            echo "Checking health endpoint..."
+                            curl -sk "$(echo "$CODESIGNING_SERVICE_URL" | sed -E 's|(/sign)?/*$||')/healthz"
+                            '''
+
+                            sh '''
+                            CodeSigningClient="./build/linux-x64/TownSuite.CodeSigning.Client/TownSuite.CodeSigning.Client"
+                            chmod +x "$CodeSigningClient"
+                            "$CodeSigningClient" -rfolder "build|*TownSuite*.dll;*TownSuite*.exe" -excludefolders "pkg-linux-amd64;pkg-linux-arm64" -url "$CODESIGNING_SERVICE_URL" -timeout 60000 -token "$CODESIGNING_AUTH_KEY" -ignorecerts
+                            '''
+                        }
+
+                        // informational signature status, mirrors the windows
+                        // Get-AuthenticodeSignature step
+                        sh '''
+                        osslsigncode verify -in "build/linux-x64/TownSuite.CodeSigning.Service/TownSuite.CodeSigning.Service.dll" || true
+                        osslsigncode verify -in "build/linux-arm64/TownSuite.CodeSigning.Service/TownSuite.CodeSigning.Service.dll" || true
+                        '''
+
+                        // build_linux.sh zips before signing runs, so re-pack the Service zips
+                        // (the only ones whose contents changed) with the signed dlls. The
+                        // Client zips/debs hold a single-file ELF which is not Authenticode
+                        // signable and are left as built.
+                        sh '''
+                        VERSION=$(cat Directory.Build.props | grep "<Version>" | sed 's/[^0-9.]*//g')
+                        cd build
+                        rm -f "TownSuite.CodeSigning.Service-$VERSION-linux-x64.zip" "TownSuite.CodeSigning.Service-$VERSION-linux-arm64.zip"
+                        zip -r "TownSuite.CodeSigning.Service-$VERSION-linux-x64.zip" linux-x64/TownSuite.CodeSigning.Service
+                        zip -r "TownSuite.CodeSigning.Service-$VERSION-linux-arm64.zip" linux-arm64/TownSuite.CodeSigning.Service
+                        sha256sum "TownSuite.CodeSigning.Service-$VERSION-linux-x64.zip" > "TownSuite.CodeSigning.Service-$VERSION-linux-x64.zip.SHA256SUMS"
+                        sha256sum "TownSuite.CodeSigning.Service-$VERSION-linux-arm64.zip" > "TownSuite.CodeSigning.Service-$VERSION-linux-arm64.zip.SHA256SUMS"
+                        '''
+
                         echo 'archiving artifacts'
                         script {
                             townsuite.archiveWithRetryAndLock('build/*.zip,build/*.SHA256SUMS', 3)

--- a/TownSuite.CodeSigning.Client/FileHelpers.cs
+++ b/TownSuite.CodeSigning.Client/FileHelpers.cs
@@ -31,25 +31,129 @@ public static class FileHelpers
     /// Checks whether a file has an embedded Authenticode signature. Used both to skip files
     /// that are already signed before upload, and to verify that a file returned by the signing
     /// service actually has a signature attached before treating the download as successful.
+    ///
+    /// PE files (exe/dll/sys/ocx) are checked by reading the Certificate Table out of the PE
+    /// header, which works on any OS. Non-PE containers (msi/cab/msix/appx) fall back to
+    /// X509Certificate2, which can only extract an Authenticode signer on Windows - so on Linux
+    /// those container formats always report unsigned.
     /// </summary>
     public static bool HasEmbeddedDigitalSignature(string file)
     {
-        try
+        if (HasPeAuthenticodeSignature(file))
         {
-            using (var cert = new X509Certificate2(file))
+            return true;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            try
             {
-                if (cert != null)
+                using (var cert = new X509Certificate2(file))
                 {
-                    return true;
+                    if (cert != null)
+                    {
+                        return true;
+                    }
                 }
             }
-        }
-        catch (Exception)
-        {
-            // Ignore any exceptions
+            catch (Exception)
+            {
+                // Ignore any exceptions
+            }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Cross-platform Authenticode presence check: locates the Certificate Table entry in the
+    /// PE optional header's data directories and decodes the WIN_CERTIFICATE blob it points at
+    /// as CMS SignedData. Returns false for anything that is not a signed PE file.
+    /// </summary>
+    internal static bool HasPeAuthenticodeSignature(string file)
+    {
+        try
+        {
+            using var fs = System.IO.File.OpenRead(file);
+            using var reader = new BinaryReader(fs);
+
+            if (fs.Length < 0x40 || reader.ReadUInt16() != 0x5A4D) // "MZ"
+            {
+                return false;
+            }
+
+            fs.Position = 0x3C;
+            uint peHeaderOffset = reader.ReadUInt32();
+            if (peHeaderOffset + 24 > fs.Length)
+            {
+                return false;
+            }
+
+            fs.Position = peHeaderOffset;
+            if (reader.ReadUInt32() != 0x00004550) // "PE\0\0"
+            {
+                return false;
+            }
+
+            // COFF header is 20 bytes; the optional header follows it.
+            long optionalHeaderOffset = peHeaderOffset + 24;
+            fs.Position = optionalHeaderOffset;
+            ushort magic = reader.ReadUInt16();
+
+            // Data directories start at offset 96 (PE32, magic 0x10B) or 112 (PE32+, magic 0x20B)
+            // within the optional header; the Certificate Table is directory index 4.
+            long dataDirectoriesOffset;
+            if (magic == 0x10B)
+            {
+                dataDirectoriesOffset = optionalHeaderOffset + 96;
+            }
+            else if (magic == 0x20B)
+            {
+                dataDirectoriesOffset = optionalHeaderOffset + 112;
+            }
+            else
+            {
+                return false;
+            }
+
+            fs.Position = dataDirectoriesOffset - 4;
+            uint numberOfRvaAndSizes = reader.ReadUInt32();
+            if (numberOfRvaAndSizes < 5)
+            {
+                return false;
+            }
+
+            fs.Position = dataDirectoriesOffset + 4 * 8;
+            uint certTableOffset = reader.ReadUInt32(); // a file offset, not an RVA
+            uint certTableSize = reader.ReadUInt32();
+
+            // WIN_CERTIFICATE header is 8 bytes: dwLength, wRevision, wCertificateType.
+            if (certTableOffset == 0 || certTableSize < 8
+                || (long)certTableOffset + certTableSize > fs.Length)
+            {
+                return false;
+            }
+
+            fs.Position = certTableOffset;
+            uint certLength = reader.ReadUInt32();
+            fs.Position += 2; // wRevision
+            ushort certType = reader.ReadUInt16();
+
+            const ushort WIN_CERT_TYPE_PKCS_SIGNED_DATA = 0x0002;
+            if (certType != WIN_CERT_TYPE_PKCS_SIGNED_DATA || certLength < 8 || certLength > certTableSize)
+            {
+                return false;
+            }
+
+            byte[] pkcs7 = reader.ReadBytes((int)certLength - 8);
+            var signedCms = new SignedCms();
+            signedCms.Decode(pkcs7);
+            return signedCms.SignerInfos.Count > 0;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/TownSuite.CodeSigning.ClientTests/ClientFileHelpersTest.cs
+++ b/TownSuite.CodeSigning.ClientTests/ClientFileHelpersTest.cs
@@ -132,6 +132,63 @@ namespace TownSuite.CodeSigning.ClientTests
         {
             Assert.IsFalse(FileHelpers.HasEmbeddedDigitalSignature(Path.Combine(_tempDir, "does-not-exist.dll")));
         }
+
+        // The PE parser is what makes signature detection work on Linux, where the
+        // X509Certificate2 fallback cannot read Authenticode signatures out of PE files.
+        // Exercising it directly proves the cross-platform path works without that fallback.
+        [Test]
+        public void HasPeAuthenticodeSignature_ReturnsTrue_ForSignedDll()
+        {
+            Assert.IsTrue(FileHelpers.HasPeAuthenticodeSignature(_signedDllCopy));
+        }
+
+        [Test]
+        public void HasPeAuthenticodeSignature_ReturnsFalse_ForUnsignedDll()
+        {
+            Assert.IsFalse(FileHelpers.HasPeAuthenticodeSignature(_unsignedDllCopy));
+        }
+
+        [Test]
+        public void HasPeAuthenticodeSignature_ReturnsFalse_ForNonPeFile()
+        {
+            string textFile = Path.Combine(_tempDir, "not-a-pe.dll");
+            File.WriteAllText(textFile, "this is not a portable executable");
+            Assert.IsFalse(FileHelpers.HasPeAuthenticodeSignature(textFile));
+        }
+
+        [Test]
+        public void HasPeAuthenticodeSignature_ReturnsFalse_ForTruncatedPeFile()
+        {
+            // Valid DOS magic but the file ends before the PE header can exist.
+            string truncated = Path.Combine(_tempDir, "truncated.dll");
+            File.WriteAllBytes(truncated, new byte[] { 0x4D, 0x5A, 0x90, 0x00 });
+            Assert.IsFalse(FileHelpers.HasPeAuthenticodeSignature(truncated));
+        }
+
+        [Test]
+        public void HasPeAuthenticodeSignature_ReturnsFalse_WhenCertTableContainsGarbage()
+        {
+            // Take the signed dll and corrupt the start of the PKCS#7 blob the certificate
+            // table points at (its outer ASN.1 SEQUENCE header), leaving the WIN_CERTIFICATE
+            // header intact - the SignedCms decode should reject it.
+            byte[] bytes = File.ReadAllBytes(_signedDllCopy);
+
+            uint peHeaderOffset = BitConverter.ToUInt32(bytes, 0x3C);
+            ushort magic = BitConverter.ToUInt16(bytes, (int)peHeaderOffset + 24);
+            int dataDirectoriesOffset = (int)peHeaderOffset + 24 + (magic == 0x20B ? 112 : 96);
+            uint certTableOffset = BitConverter.ToUInt32(bytes, dataDirectoriesOffset + 4 * 8);
+            Assert.That(certTableOffset, Is.Not.Zero, "test asset should carry a certificate table");
+
+            int pkcs7Start = (int)certTableOffset + 8; // skip the WIN_CERTIFICATE header
+            for (int i = 0; i < 16; i++)
+            {
+                bytes[pkcs7Start + i] ^= 0xFF;
+            }
+
+            string corrupted = Path.Combine(_tempDir, "corrupted_signature.dll");
+            File.WriteAllBytes(corrupted, bytes);
+            Assert.IsFalse(FileHelpers.HasPeAuthenticodeSignature(corrupted));
+        }
     }
 
     [TestFixture]


### PR DESCRIPTION
Detect embedded Authenticode signatures by reading the PE certificate table and decoding it with SignedCms instead of relying on the Windows-only X509Certificate2 path, which always reported files as unsigned on Linux. Non-PE containers (msi/cab/msix/appx) still fall back to X509Certificate2 on Windows.

Add a Linux sign-and-verify stage to the Jenkins pipeline mirroring the Windows flow, re-packing the Service zips with the signed dlls.