### PR TITLE
Skip X509Certificate2 fallback for PE files in signature check 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>26.10.3</AssemblyVersion>
-    <FileVersion>26.10.3</FileVersion>
-    <Version>26.10.3</Version>
+    <AssemblyVersion>26.10.4</AssemblyVersion>
+    <FileVersion>26.10.4</FileVersion>
+    <Version>26.10.4</Version>
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Company>TownSuite Municipal Software Inc.</Company>

--- a/TownSuite.CodeSigning.Client/FileHelpers.cs
+++ b/TownSuite.CodeSigning.Client/FileHelpers.cs
@@ -33,15 +33,24 @@ public static class FileHelpers
     /// service actually has a signature attached before treating the download as successful.
     ///
     /// PE files (exe/dll/sys/ocx) are checked by reading the Certificate Table out of the PE
-    /// header, which works on any OS. Non-PE containers (msi/cab/msix/appx) fall back to
-    /// X509Certificate2, which can only extract an Authenticode signer on Windows - so on Linux
-    /// those container formats always report unsigned.
+    /// header, which works on any OS and is authoritative - an unsigned PE has no cert table entry
+    /// regardless of platform. The X509Certificate2 fallback only runs for non-PE containers
+    /// (msi/cab/msix/appx), where it can extract an Authenticode signer on Windows only (on Linux
+    /// those container formats always report unsigned). It must not run for PE files: repackaged
+    /// Electron/Chromium exe content has been observed to false-positive as "signed" when the whole
+    /// file is handed to X509Certificate2, even though HasPeAuthenticodeSignature correctly reports
+    /// no certificate table entry.
     /// </summary>
     public static bool HasEmbeddedDigitalSignature(string file)
     {
         if (HasPeAuthenticodeSignature(file))
         {
             return true;
+        }
+
+        if (IsPeFile(file))
+        {
+            return false;
         }
 
         if (OperatingSystem.IsWindows())
@@ -63,6 +72,39 @@ public static class FileHelpers
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Checks the MZ/PE magic bytes only - used to decide whether the Certificate Table check in
+    /// HasPeAuthenticodeSignature is authoritative (true PE files) or whether the X509Certificate2
+    /// fallback should be tried instead (non-PE containers such as msi/cab/msix/appx).
+    /// </summary>
+    internal static bool IsPeFile(string file)
+    {
+        try
+        {
+            using var fs = System.IO.File.OpenRead(file);
+            using var reader = new BinaryReader(fs);
+
+            if (fs.Length < 0x40 || reader.ReadUInt16() != 0x5A4D) // "MZ"
+            {
+                return false;
+            }
+
+            fs.Position = 0x3C;
+            uint peHeaderOffset = reader.ReadUInt32();
+            if (peHeaderOffset + 4 > fs.Length)
+            {
+                return false;
+            }
+
+            fs.Position = peHeaderOffset;
+            return reader.ReadUInt32() == 0x00004550; // "PE\0\0"
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/TownSuite.CodeSigning.ClientTests/ClientFileHelpersTest.cs
+++ b/TownSuite.CodeSigning.ClientTests/ClientFileHelpersTest.cs
@@ -189,6 +189,44 @@ namespace TownSuite.CodeSigning.ClientTests
             File.WriteAllBytes(corrupted, bytes);
             Assert.IsFalse(FileHelpers.HasPeAuthenticodeSignature(corrupted));
         }
+
+        // IsPeFile gates the X509Certificate2 fallback in HasEmbeddedDigitalSignature so it only
+        // runs for non-PE containers (msi/cab/msix/appx). Without this gate, repackaged
+        // Electron/Chromium exe content was observed to false-positive as "signed" when handed
+        // whole to X509Certificate2, even though it has no Certificate Table entry - which made
+        // the client silently skip signing those exes. See HasEmbeddedDigitalSignature doc comment.
+        [Test]
+        public void IsPeFile_ReturnsTrue_ForValidPeFile()
+        {
+            Assert.IsTrue(FileHelpers.IsPeFile(_unsignedDllCopy));
+        }
+
+        [Test]
+        public void IsPeFile_ReturnsFalse_ForNonPeFile()
+        {
+            string textFile = Path.Combine(_tempDir, "not-a-pe.dll");
+            File.WriteAllText(textFile, "this is not a portable executable");
+            Assert.IsFalse(FileHelpers.IsPeFile(textFile));
+        }
+
+        [Test]
+        public void IsPeFile_ReturnsFalse_ForTruncatedFile()
+        {
+            string truncated = Path.Combine(_tempDir, "truncated.dll");
+            File.WriteAllBytes(truncated, new byte[] { 0x4D, 0x5A, 0x90, 0x00 });
+            Assert.IsFalse(FileHelpers.IsPeFile(truncated));
+        }
+
+        [Test]
+        public void HasEmbeddedDigitalSignature_DoesNotFallBackToX509Certificate2_ForUnsignedPeFile()
+        {
+            // Regression guard: an unsigned PE must report unsigned even on Windows, without
+            // relying on X509Certificate2 - that fallback is what previously false-positived on
+            // Electron/Chromium exe content and caused the client to skip signing it.
+            Assert.IsTrue(FileHelpers.IsPeFile(_unsignedDllCopy));
+            Assert.IsFalse(FileHelpers.HasPeAuthenticodeSignature(_unsignedDllCopy));
+            Assert.IsFalse(FileHelpers.HasEmbeddedDigitalSignature(_unsignedDllCopy));
+        }
     }
 
     [TestFixture]


### PR DESCRIPTION
HasEmbeddedDigitalSignature fell back to X509Certificate2 whenever the
PE certificate-table check found no signature, and that fallback
false-positives on Electron/Chromium exe content - causing the client
to silently skip signing them. Gate the fallback to non-PE containers
only (msi/cab/msix/appx); PE files now rely solely on the certificate-
table read, which is authoritative.