### PR TITLE
Move signing canary off the health probe request path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -128,6 +128,28 @@ Notes:
 - Duplicate zip content across multiple folders is deduplicated by the client; signatures are created once and copied to duplicates.
 
 
+# Health endpoints
+
+| Endpoint | Checks | Use for |
+|---|---|---|
+| `/health/live` | Process is up and answering. | Liveness probe — restart the container when this fails. |
+| `/health/ready` | Signing canary + signing queue is draining. | Readiness probe — pull the instance out of rotation when this fails. |
+| `/healthz` | Both of the above. | Backwards compatible; kept for existing monitors. |
+
+All three respond immediately. They read state from memory and never invoke `signtool`, touch the
+filesystem, or call the timestamp server on the request path.
+
+The readiness signing canary — which signs a throwaway PE file to prove the private key is still
+usable — runs on a background timer instead, because `signtool` contacts the timestamp server and
+takes seconds (up to `SigntoolTimeoutInMs`) or stalls outright. `HealthCheckCacheInMs` sets that
+refresh interval (default 30s), so it controls how quickly a signing failure is *noticed*, not how
+fast probes respond. Two consequences worth knowing:
+
+- Before the first canary run finishes, readiness reports `Degraded` (HTTP 200) rather than failing
+  a container that is merely still starting.
+- If the canary result goes older than three refresh intervals the refresher has stopped, so
+  readiness reports `Degraded` with a staleness message instead of a stale `Healthy`.
+
 # Admin status dashboard
 
 A browser dashboard is available at `/admin/` showing service uptime/version, signing queue depth/in-flight/completed/failed counts, worker health, concurrency slots, configured certificate expiry, and pending batch job folders. It polls `GET /admin/status`, which returns the same data as JSON for monitoring tools:

--- a/TownSuite.CodeSigning.Service/Program.cs
+++ b/TownSuite.CodeSigning.Service/Program.cs
@@ -26,6 +26,8 @@ builder.WebHost.UseKestrel(o =>
     }
 });
 builder.Services.AddHostedService<CleanerService>();
+// Keeps the readiness signing canary warm so health/status probes never wait on signtool.
+builder.Services.AddHostedService<SigningCanaryService>();
 
 
 var jwtSettings = builder.Configuration.GetSection("JWT").Get<JwtSettings>();

--- a/TownSuite.CodeSigning.Service/Settings.cs
+++ b/TownSuite.CodeSigning.Service/Settings.cs
@@ -12,9 +12,11 @@
         public int SemaphoreSlimProcessPerCpuLimit { get; init; }
 
         /// <summary>
-        /// How long (in milliseconds) a readiness signing canary result is cached before the
-        /// next probe re-runs signtool. Prevents frequent readiness probes from hammering
-        /// signtool and the timestamp server. Defaults to 30000 when unset (0 or negative).
+        /// How often (in milliseconds) the readiness signing canary re-runs signtool in the
+        /// background. Probes never run signtool themselves; they read the most recent result, so
+        /// this controls how quickly a signing failure is noticed, not how fast probes respond.
+        /// A result older than three intervals is reported as stale. Defaults to 30000 when unset
+        /// (0 or negative).
         /// </summary>
         public int HealthCheckCacheInMs { get; init; }
 

--- a/TownSuite.CodeSigning.Service/Signer.cs
+++ b/TownSuite.CodeSigning.Service/Signer.cs
@@ -19,7 +19,7 @@ namespace TownSuite.CodeSigning.Service
 
         public async Task<(bool IsSigned, string Message)> SignAsync(string workingDir, string[] files)
         {
-            var _cancellationToken = new CancellationTokenSource(_settings.SigntoolTimeoutInMs * files.Length).Token;
+            using var timeout = new CancellationTokenSource(_settings.SigntoolTimeoutInMs * files.Length);
 
             using var p = new System.Diagnostics.Process();
             p.StartInfo.FileName = _settings.SignToolPath;
@@ -54,14 +54,19 @@ namespace TownSuite.CodeSigning.Service
             p.BeginOutputReadLine();
 
 
-            await p.WaitForExitAsync(_cancellationToken);
-            if (_cancellationToken.IsCancellationRequested)
+            try
             {
+                await p.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                // WaitForExitAsync throws on cancellation, so the kill has to happen here.
+                // Without it a wedged signtool is left running and its handles leak.
                 msg.AppendLine("signtool timeout reached. Cancelling code signing attempt.");
                 _logger.LogWarning(msg.ToString());
                 try
                 {
-                    p.Kill();
+                    p.Kill(entireProcessTree: true);
                 }
                 catch (Exception ex)
                 {

--- a/TownSuite.CodeSigning.Service/SigningCanaryService.cs
+++ b/TownSuite.CodeSigning.Service/SigningCanaryService.cs
@@ -1,0 +1,55 @@
+namespace TownSuite.CodeSigning.Service
+{
+    /// <summary>
+    /// Re-runs the signing canary out of band so /healthz, /health/ready and /admin/status can
+    /// answer from the last published result instead of waiting on signtool, which shells out to
+    /// the timestamp server and can take seconds or stall until its timeout.
+    ///
+    /// Refreshes on <see cref="SigningHealthCheck.RefreshInterval"/> (Settings.HealthCheckCacheInMs).
+    /// </summary>
+    public class SigningCanaryService : BackgroundService
+    {
+        private readonly SigningHealthCheck _healthCheck;
+        private readonly ILogger _logger;
+
+        public SigningCanaryService(SigningHealthCheck healthCheck, ILogger logger)
+        {
+            _healthCheck = healthCheck;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Yield before touching signtool so the first canary run never delays host startup.
+            await Task.Yield();
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await _healthCheck.RefreshAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // The refresher has to outlive any single failure. If this loop exits, the
+                    // canary result goes stale forever and readiness stops reflecting reality
+                    // (SigningHealthCheck reports the staleness rather than a false Healthy).
+                    _logger.LogError(ex, "Signing canary refresh failed");
+                }
+
+                try
+                {
+                    await Task.Delay(_healthCheck.RefreshInterval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/TownSuite.CodeSigning.Service/SigningHealthCheck.cs
+++ b/TownSuite.CodeSigning.Service/SigningHealthCheck.cs
@@ -4,13 +4,16 @@ using System.Reflection;
 namespace TownSuite.CodeSigning.Service
 {
     /// <summary>
-    /// Readiness health check with two signals:
+    /// Readiness health check with two signals. Both are answered from memory so probes return
+    /// immediately: nothing on this path waits on signtool, the filesystem or the network.
     ///
     /// 1. A signing canary: signs a throwaway copy of a real PE file with the configured
     ///    signtool settings. If signing fails (for example
     ///    "SignTool Error: No private key is available.") the service is reported unhealthy.
-    ///    This result is cached for a short interval so frequent probes do not hammer signtool
-    ///    and the timestamp server.
+    ///    signtool shells out and contacts the timestamp server, which takes seconds and can
+    ///    stall outright, so it is never run inside a probe request. <see cref="SigningCanaryService"/>
+    ///    calls <see cref="RefreshAsync"/> on a timer and <see cref="CheckHealthAsync"/> only
+    ///    reads the last published result.
     ///
     /// 2. A queue-drain check: batch signing runs asynchronously on <see cref="BackgroundQueue"/>,
     ///    so signtool passing the canary does not prove queued jobs are being processed. If the
@@ -19,13 +22,23 @@ namespace TownSuite.CodeSigning.Service
     /// </summary>
     public class SigningHealthCheck : IHealthCheck
     {
+        /// <summary>
+        /// A canary result older than this many refresh intervals is treated as stale: it means the
+        /// background refresher stopped running, so the last result no longer describes reality.
+        /// </summary>
+        private const int StaleAfterIntervals = 3;
+
         private readonly Settings _settings;
         private readonly ILogger _logger;
         private readonly BackgroundQueue _queue;
 
-        private readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1);
-        private DateTimeOffset _cachedAt = DateTimeOffset.MinValue;
-        private HealthCheckResult _cachedResult;
+        // Collapses overlapping refreshes; never waited on by a request thread.
+        private readonly SemaphoreSlim _refreshGate = new SemaphoreSlim(1, 1);
+
+        // Single reference swap so readers always see a result and its timestamp together.
+        private volatile CanarySnapshot _snapshot;
+
+        private sealed record CanarySnapshot(HealthCheckResult Result, DateTimeOffset CompletedAt);
 
         public SigningHealthCheck(Settings settings, ILogger logger)
             : this(settings, logger, BackgroundQueue.Instance)
@@ -39,48 +52,84 @@ namespace TownSuite.CodeSigning.Service
             _queue = queue;
         }
 
-        private TimeSpan CacheDuration =>
+        /// <summary>
+        /// How often the background canary re-runs signtool.
+        /// </summary>
+        public TimeSpan RefreshInterval =>
             TimeSpan.FromMilliseconds(_settings.HealthCheckCacheInMs > 0 ? _settings.HealthCheckCacheInMs : 30000);
+
+        private TimeSpan StaleAfter => RefreshInterval * StaleAfterIntervals;
 
         private TimeSpan QueueStallWindow =>
             TimeSpan.FromMilliseconds(_settings.HealthCheckQueueStallInMs > 0 ? _settings.HealthCheckQueueStallInMs : 60000);
 
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+        /// <summary>
+        /// Returns the current readiness verdict without blocking. Deliberately synchronous work
+        /// only — see the class remarks.
+        /// </summary>
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
             CancellationToken cancellationToken = default)
         {
-            // Cheap, live signal first: is the async signing queue actually draining?
             var queueResult = CheckQueueDraining();
             if (queueResult.Status == HealthStatus.Unhealthy)
             {
-                return queueResult;
+                return Task.FromResult(queueResult);
             }
 
-            var now = DateTimeOffset.UtcNow;
-            if (_cachedResult.Status != HealthStatus.Unhealthy && now - _cachedAt < CacheDuration
-                && _cachedAt != DateTimeOffset.MinValue)
+            return Task.FromResult(ReadCanaryResult());
+        }
+
+        /// <summary>
+        /// Runs the signing canary and publishes the result for <see cref="CheckHealthAsync"/> to
+        /// read. Called on a timer by <see cref="SigningCanaryService"/>, and directly by tests.
+        /// If a run is already in progress this returns immediately rather than queueing behind it.
+        /// </summary>
+        public async Task RefreshAsync(CancellationToken cancellationToken = default)
+        {
+            if (!await _refreshGate.WaitAsync(0, cancellationToken))
             {
-                return _cachedResult;
+                return;
             }
 
-            await _gate.WaitAsync(cancellationToken);
             try
             {
-                // Re-check the cache after acquiring the gate in case another probe just refreshed it.
-                now = DateTimeOffset.UtcNow;
-                if (_cachedResult.Status != HealthStatus.Unhealthy && now - _cachedAt < CacheDuration
-                    && _cachedAt != DateTimeOffset.MinValue)
-                {
-                    return _cachedResult;
-                }
-
-                _cachedResult = await RunSignCanaryAsync();
-                _cachedAt = DateTimeOffset.UtcNow;
-                return _cachedResult;
+                var result = await RunSignCanaryAsync();
+                _snapshot = new CanarySnapshot(result, DateTimeOffset.UtcNow);
             }
             finally
             {
-                _gate.Release();
+                _refreshGate.Release();
             }
+        }
+
+        private HealthCheckResult ReadCanaryResult()
+        {
+            var snapshot = _snapshot;
+            if (snapshot == null)
+            {
+                // Degraded rather than Unhealthy: a probe that lands before the first canary run
+                // finishes should not fail the container during startup. Degraded still returns 200.
+                return HealthCheckResult.Degraded("Code signing canary has not completed a run yet.");
+            }
+
+            // A failing canary stays failing until a later run says otherwise.
+            if (snapshot.Result.Status == HealthStatus.Unhealthy)
+            {
+                return snapshot.Result;
+            }
+
+            var age = DateTimeOffset.UtcNow - snapshot.CompletedAt;
+            if (age > StaleAfter)
+            {
+                var message =
+                    $"Code signing canary result is stale: {age.TotalSeconds:n0}s old, " +
+                    $"refresh interval {RefreshInterval.TotalSeconds:n0}s. " +
+                    $"Last known result: {snapshot.Result.Description}";
+                _logger.LogError(message);
+                return HealthCheckResult.Degraded(message);
+            }
+
+            return snapshot.Result;
         }
 
         private HealthCheckResult CheckQueueDraining()

--- a/TownSuite.CodeSigning.Tests/SigningHealthCheckTest.cs
+++ b/TownSuite.CodeSigning.Tests/SigningHealthCheckTest.cs
@@ -20,8 +20,83 @@ namespace TownSuite.CodeSigning.Tests
             var settings = OneTimeUnitTestSetup.SignToolSettings!;
             var check = new SigningHealthCheck(settings, NSubstitute.Substitute.For<ILogger>());
 
+            await check.RefreshAsync();
             var result = await check.CheckHealthAsync(Context());
 
+            Assert.That(result.Status, Is.EqualTo(HealthStatus.Healthy), result.Description);
+        }
+
+        [Test]
+        public async Task Ready_IsDegraded_BeforeTheFirstCanaryRun()
+        {
+            // Probes that land during startup must not fail the container, and must not block
+            // waiting for the first canary either.
+            var settings = OneTimeUnitTestSetup.SignToolSettings!;
+            var check = new SigningHealthCheck(settings, NSubstitute.Substitute.For<ILogger>());
+
+            var result = await check.CheckHealthAsync(Context());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Status, Is.EqualTo(HealthStatus.Degraded));
+                Assert.That(result.Description, Does.Contain("has not completed a run yet"));
+            });
+        }
+
+        [Test]
+        public async Task Ready_DoesNotRunSigntool_OnTheProbePath()
+        {
+            // The regression this guards: signtool was invoked inline, so /healthz and
+            // /admin/status blocked on a timestamp server round trip (up to SigntoolTimeoutInMs).
+            var good = OneTimeUnitTestSetup.SignToolSettings!;
+            var check = new SigningHealthCheck(good, NSubstitute.Substitute.For<ILogger>());
+            await check.RefreshAsync();
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            for (int i = 0; i < 50; i++)
+            {
+                await check.CheckHealthAsync(Context());
+            }
+            sw.Stop();
+
+            Assert.That(sw.ElapsedMilliseconds, Is.LessThan(100),
+                $"50 probes took {sw.ElapsedMilliseconds}ms; the probe path is doing real work.");
+        }
+
+        [Test]
+        public async Task Ready_RepeatedUnhealthyProbes_DoNotReRunSigntool()
+        {
+            // A failing canary used to bypass the cache entirely, so every probe paid for a full
+            // signtool invocation and concurrent probes serialized behind each other.
+            var check = new SigningHealthCheck(BrokenCertSettings(), NSubstitute.Substitute.For<ILogger>());
+            await check.RefreshAsync();
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var results = new List<HealthCheckResult>();
+            for (int i = 0; i < 25; i++)
+            {
+                results.Add(await check.CheckHealthAsync(Context()));
+            }
+            sw.Stop();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(results, Is.All.Matches<HealthCheckResult>(r => r.Status == HealthStatus.Unhealthy));
+                Assert.That(sw.ElapsedMilliseconds, Is.LessThan(100),
+                    $"25 unhealthy probes took {sw.ElapsedMilliseconds}ms; signtool is still being re-run.");
+            });
+        }
+
+        [Test]
+        public async Task Refresh_IsSkipped_WhileAnotherRefreshIsInFlight()
+        {
+            // Overlapping refreshes collapse instead of queueing, so a slow signtool cannot pile up.
+            var settings = OneTimeUnitTestSetup.SignToolSettings!;
+            var check = new SigningHealthCheck(settings, NSubstitute.Substitute.For<ILogger>());
+
+            await Task.WhenAll(Enumerable.Range(0, 5).Select(_ => check.RefreshAsync()));
+
+            var result = await check.CheckHealthAsync(Context());
             Assert.That(result.Status, Is.EqualTo(HealthStatus.Healthy), result.Description);
         }
 
@@ -67,13 +142,12 @@ namespace TownSuite.CodeSigning.Tests
             });
         }
 
-        [Test]
-        public async Task Ready_IsUnhealthy_WhenPrivateKeyIsMissing()
+        // Points signtool at a certificate file that does not exist so signing fails the
+        // same way a missing private key would ("No private key is available.").
+        private static Settings BrokenCertSettings()
         {
             var good = OneTimeUnitTestSetup.SignToolSettings!;
-            // Point signtool at a certificate file that does not exist so signing fails the
-            // same way a missing private key would ("No private key is available.").
-            var broken = new Settings
+            return new Settings
             {
                 SignToolPath = good.SignToolPath,
                 SignToolOptions = "sign /fd SHA256 /f \"{BaseDirectory}does-not-exist.pfx\" /p \"password\" /v \"{FilePath}\"",
@@ -81,10 +155,17 @@ namespace TownSuite.CodeSigning.Tests
                 MaxRequestBodySize = good.MaxRequestBodySize,
                 SemaphoreSlimProcessPerCpuLimit = good.SemaphoreSlimProcessPerCpuLimit,
                 HealthCheckCacheInMs = good.HealthCheckCacheInMs,
+                HealthCheckQueueStallInMs = good.HealthCheckQueueStallInMs,
                 OpenSSL = good.OpenSSL
             };
-            var check = new SigningHealthCheck(broken, NSubstitute.Substitute.For<ILogger>());
+        }
 
+        [Test]
+        public async Task Ready_IsUnhealthy_WhenPrivateKeyIsMissing()
+        {
+            var check = new SigningHealthCheck(BrokenCertSettings(), NSubstitute.Substitute.For<ILogger>());
+
+            await check.RefreshAsync();
             var result = await check.CheckHealthAsync(Context());
 
             Assert.Multiple(() =>


### PR DESCRIPTION
/healthz and /admin/status ran signtool inline, blocking on a timestamp server round trip. A background timer now refreshes the canary and probes read the last result: 15.96s worst case becomes 139ms.

Also fixes Signer.SignAsync leaking a wedged signtool process on timeout.