### PR TITLE
Sign detached signatures over raw bytes with openssl -binary

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -249,8 +249,17 @@ openssl req -x509 -nodes -key server.key -out server.crt -days 365 -nodes -subj 
 ### create a detached signature
 
 ```bash
-open cms -sign -in "{FilePath}" -signer "/path/to/server.crt" -inkey "/path/to/server.key" -keyform P12 -passin pass:password -out "{FilePath}.sig" -outform DER -md sha256
+openssl cms -sign -in "{FilePath}" -signer "/path/to/server.crt" -inkey "/path/to/server.key" -keyform P12 -passin pass:password -out "{FilePath}.sig" -outform DER -md sha256 -binary
 ```
+
+`-binary` is required. Without it OpenSSL treats the input as S/MIME text and rewrites every line
+ending to CRLF before computing the digest, so the signature covers the canonicalized form rather
+than the bytes on disk. That is OpenSSL behaviour, not OS behaviour - it happens identically on
+Windows and Linux. It only goes unnoticed when the input already uses CRLF throughout; for LF text
+and for any binary (zip, dll, exe, msi) the resulting `.sig` does not match the file being shipped.
+
+`-binary` must be used on **both** sides. Signatures issued before this flag was added verify only
+*without* `-binary`; signatures issued after it verify only *with* it.
 
 ### Timestamp a detached signature
 
@@ -282,4 +291,7 @@ openssl pkcs12 -in "server.pfx" -nokeys -out "server.cer"
 ```bash
 openssl cms -verify -binary -inform DER -in archive.zip.sig -content archive.zip -CAfile server.cer > /dev/null
 ```
+
+The `-binary` here must match the flag used at signing time (see above), otherwise the digest is
+computed over differently canonicalized bytes and verification fails.
 

--- a/TownSuite.CodeSigning.Client/FileHelpers.cs
+++ b/TownSuite.CodeSigning.Client/FileHelpers.cs
@@ -199,19 +199,18 @@ public static class FileHelpers
     }
 
     /// <summary>
-    /// Checks that a detached signature file is a structurally valid CMS SignedData blob
-    /// carrying a signer and an embedded certificate - the certificate lives in this side-by-side
-    /// .sig file, never in the original dll/exe/zip.
+    /// Verifies that a detached signature actually covers the bytes of the original file. The
+    /// signing certificate lives in this side-by-side .sig file, never in the original dll/exe/zip.
     ///
-    /// This is a structural check only, not a content-hash verification. The signing service's
-    /// OpenSSL invocation signs without "-binary", so it applies S/MIME text canonicalization
-    /// (CRLF normalization) to the content before hashing. Recomputing that transform here to
-    /// verify the digest would mean reimplementing OpenSSL's canonicalization byte-for-byte in
-    /// .NET; probing it directly showed it does not survive a clean round-trip for arbitrary
-    /// binary content (e.g. embedded NUL bytes were lost), so a from-scratch reimplementation
-    /// cannot be trusted not to reject legitimately signed files. As a result this check catches
-    /// a missing, empty, or corrupt .sig, but will not detect a structurally valid signature that
-    /// was produced over different content.
+    /// The service signs with OpenSSL's "-binary" flag, so the digest is computed over the content
+    /// exactly as it sits on disk. That is what makes a byte-exact check possible here: any
+    /// difference in content - including a line-ending rewrite somewhere in the pipeline - is
+    /// rejected. Without "-binary" openssl digests a CRLF-canonicalized copy instead, which is why
+    /// this check used to be structural-only.
+    ///
+    /// Scope: verifySignatureOnly means this proves integrity, not trust. It confirms the signature
+    /// was made over this exact content by the certificate embedded in the .sig; it does not build
+    /// a chain to a trusted root, so on its own it does not establish who the signer is.
     /// </summary>
     public static bool HasValidDetachedSignature(string originalFilePath, string signatureFilePath)
     {
@@ -233,7 +232,14 @@ public static class FileHelpers
             var signedCms = new SignedCms(contentInfo, detached: true);
             signedCms.Decode(signatureBytes);
 
-            return signedCms.SignerInfos.Count > 0 && signedCms.Certificates.Count > 0;
+            if (signedCms.SignerInfos.Count == 0 || signedCms.Certificates.Count == 0)
+            {
+                return false;
+            }
+
+            // Throws if the digest does not match originalBytes.
+            signedCms.CheckSignature(verifySignatureOnly: true);
+            return true;
         }
         catch (Exception)
         {

--- a/TownSuite.CodeSigning.ClientTests/ClientFileHelpersTest.cs
+++ b/TownSuite.CodeSigning.ClientTests/ClientFileHelpersTest.cs
@@ -310,13 +310,12 @@ namespace TownSuite.CodeSigning.ClientTests
         }
 
         [Test]
-        public void HasValidDetachedSignature_ReturnsTrue_EvenForMismatchedContent_ByDesign()
+        public void HasValidDetachedSignature_ReturnsFalse_ForMismatchedContent()
         {
-            // This is a structural check only (SignerInfo + embedded cert present), not a content
-            // hash verification - see the HasValidDetachedSignature doc comment for why: the
-            // signing service signs without OpenSSL's "-binary" flag, so the real digest is
-            // computed over S/MIME-canonicalized content the client cannot safely reproduce.
-            // Documenting this here so the tradeoff isn't rediscovered as a "bug" later.
+            // The service signs with OpenSSL's "-binary" flag, so the digest covers the raw bytes
+            // and the client can reject a signature made over different content. This check was
+            // structural-only while signing happened without "-binary", because the digest then
+            // covered a CRLF-canonicalized copy that could not be reproduced here.
             byte[] signedContent = { 9, 9, 9 };
             string original = Path.Combine(_tempDir, "orig.bin");
             File.WriteAllBytes(original, new byte[] { 1, 2, 3 }); // different content than what was signed
@@ -324,6 +323,26 @@ namespace TownSuite.CodeSigning.ClientTests
             string sigPath = original + ".sig";
             File.WriteAllBytes(sigPath, SignDetached(signedContent));
 
+            Assert.IsFalse(FileHelpers.HasValidDetachedSignature(original, sigPath));
+        }
+
+        [Test]
+        public void HasValidDetachedSignature_ReturnsFalse_WhenLineEndingsWereRewritten()
+        {
+            // Direct guard for the manifest bug: a signature over the LF form must not validate
+            // against the CRLF form of the same text, and vice versa.
+            byte[] lf = System.Text.Encoding.UTF8.GetBytes("line1\nline2\n");
+            byte[] crlf = System.Text.Encoding.UTF8.GetBytes("line1\r\nline2\r\n");
+
+            string original = Path.Combine(_tempDir, "manifest.txt");
+            File.WriteAllBytes(original, crlf);
+
+            string sigPath = original + ".sig";
+            File.WriteAllBytes(sigPath, SignDetached(lf));
+
+            Assert.IsFalse(FileHelpers.HasValidDetachedSignature(original, sigPath));
+
+            File.WriteAllBytes(original, lf);
             Assert.IsTrue(FileHelpers.HasValidDetachedSignature(original, sigPath));
         }
     }

--- a/TownSuite.CodeSigning.Service/appsettings.json
+++ b/TownSuite.CodeSigning.Service/appsettings.json
@@ -16,7 +16,7 @@
     "HealthCheckQueueStallInMs": 60000,
     "OpenSSL": {
       "OpenSslPath": "openssl",
-      "OpenSslOptions": "cms -sign -in \"{FilePath}\" -signer \"{WorkingDirectory}public_cert.crt\" -inkey \"{WorkingDirectory}private.key\" -keyform P12 -passin pass:password -out \"{FilePath}.sig\" -outform DER -md sha256",
+      "OpenSslOptions": "cms -sign -in \"{FilePath}\" -signer \"{WorkingDirectory}public_cert.crt\" -inkey \"{WorkingDirectory}private.key\" -keyform P12 -passin pass:password -out \"{FilePath}.sig\" -outform DER -md sha256 -binary",
       "OpenSslTimeoutInMs": 30000,
       "OsslSignCodePath": "osslsigncode",
       "TimestampOptions": "add -t \"http://timestamp.digicert.com\" -in \"{FilePath}.sig\" -out \"{FilePath}.timestamped.sig\"",

--- a/TownSuite.CodeSigning.Tests/BatachedDetachedSignatureTest.cs
+++ b/TownSuite.CodeSigning.Tests/BatachedDetachedSignatureTest.cs
@@ -98,18 +98,66 @@ namespace TownSuite.CodeSigning.Tests
                 var signer = new SignerDetached(settings, NSubstitute.Substitute.For<ILogger<SignerDetached>>());
                 var signatureFile = Path.Combine(AppContext.BaseDirectory, signer.GetFileName(id));
 
+                // Byte-exact check: the digest must cover the file as it sits on disk. This is the
+                // regression guard for the "-binary" flag in OpenSslOptions - drop it and openssl
+                // silently digests a CRLF-canonicalized copy of the content instead, producing a
+                // .sig that does not match the bytes we ship. There is deliberately no fallback
+                // assertion here; a "the file exists and is non-empty" escape hatch hides exactly
+                // the defect this test exists to catch.
                 var valid = Certs.ValidateDetachedSignature(originalFile, signatureFile, OneTimeUnitTestSetup.certPath, OneTimeUnitTestSetup.password);
-                if (!valid)
-                {
-                    // If cryptographic validation isn't possible in this environment (external
-                    // tools or stores may be missing), ensure a signature file was produced.
-                    Assert.IsTrue(File.Exists(signatureFile) && new FileInfo(signatureFile).Length > 0,
-                        "Signature file was not produced or is empty and cryptographic validation failed.");
-                }
+                Assert.IsTrue(valid,
+                    $"detached signature does not verify against the original bytes of {originalFile}");
 
                 File.Delete(signatureFile);
             }
 
+        }
+
+        // Reproduction of the TownSuite.Chat manifest bug: a manifest generated on a linux agent
+        // uses LF, and openssl without "-binary" digests a CRLF-rewritten copy of it, so the .sig
+        // covers different bytes than the file that gets uploaded. Windows agents happened to write
+        // CRLF already, which made the rewrite a no-op and hid the defect. Both line endings must
+        // verify byte-exactly.
+        [TestCase("lf")]
+        [TestCase("crlf")]
+        public async Task DetachedSignature_CoversRawBytes_RegardlessOfLineEndings(string lineEnding)
+        {
+            string eol = lineEnding == "lf" ? "\n" : "\r\n";
+            string content = $"manifest-line-one{eol}manifest-line-two{eol}";
+
+            var settings = OneTimeUnitTestSetup.SignToolSettings!;
+            string id = Guid.NewGuid().ToString();
+            var workingDir = new DirectoryInfo(Path.Combine(BatchedSigning.GetTempFolder(), id));
+            workingDir.Create();
+
+            // SignerDetached deletes the originals from the working folder once it is done, so the
+            // copy used for verification has to live outside it.
+            string originalCopy = Path.Combine(AppContext.BaseDirectory, $"manifest-{lineEnding}-{id}.txt");
+            string workingFile = Path.Combine(workingDir.FullName, $"{id}.workingfile");
+
+            // WriteAllText would rewrite the line endings on the way out, which is the exact
+            // transform under test - write the bytes verbatim instead.
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(content);
+            await File.WriteAllBytesAsync(workingFile, bytes);
+            await File.WriteAllBytesAsync(originalCopy, bytes);
+
+            try
+            {
+                var signer = new SignerDetached(settings, NSubstitute.Substitute.For<ILogger<SignerDetached>>());
+                var result = await signer.SignAsync(workingDir.FullName, new[] { workingFile });
+
+                string sigPath = $"{workingFile}.sig";
+                Assert.That(File.Exists(sigPath), Is.True, $"openssl did not produce a .sig: {result.Message}");
+                Assert.That(
+                    Certs.ValidateDetachedSignature(originalCopy, sigPath, OneTimeUnitTestSetup.certPath, OneTimeUnitTestSetup.password),
+                    Is.True,
+                    $"{lineEnding} content: signature does not verify against the original bytes");
+            }
+            finally
+            {
+                try { File.Delete(originalCopy); } catch { }
+                try { workingDir.Delete(true); } catch { }
+            }
         }
     }
 }

--- a/TownSuite.CodeSigning.Tests/DetachedClientVerificationTest.cs
+++ b/TownSuite.CodeSigning.Tests/DetachedClientVerificationTest.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using TownSuite.CodeSigning.Service;
 
 namespace TownSuite.CodeSigning.Tests
@@ -6,10 +6,10 @@ namespace TownSuite.CodeSigning.Tests
     /// <summary>
     /// End-to-end compatibility test between the service's detached signing (real openssl
     /// invocation via SignerDetached) and the client's post-download verification
-    /// (FileHelpers.HasValidDetachedSignature). Guards against the client rejecting
-    /// signatures the service legitimately produced - openssl signs without "-binary",
-    /// so its digest is computed over S/MIME-canonicalized content, which is why the
-    /// client check must stay structural rather than byte-exact.
+    /// (FileHelpers.HasValidDetachedSignature). Proves the two agree byte-exactly: openssl signs
+    /// with "-binary", so the digest covers the file as it sits on disk and the client can verify
+    /// it directly. Drop that flag and openssl digests a CRLF-canonicalized copy instead, and this
+    /// test fails - which is the point of it.
     /// </summary>
     [TestFixture]
     public class DetachedClientVerificationTest

--- a/TownSuite.CodeSigning.Tests/OneTimeUnitTestSetup.cs
+++ b/TownSuite.CodeSigning.Tests/OneTimeUnitTestSetup.cs
@@ -36,7 +36,7 @@ namespace TownSuite.CodeSigning.Tests
                 OpenSSL = new OpenSSLSettings()
                 {
                     OpenSslPath = Environment.GetEnvironmentVariable("OPENSSL_PATH") ?? "openssl",
-                    OpenSslOptions = "cms -sign -in \"{FilePath}\" -signer \"{BaseDirectory}testcert.crt\" -inkey \"{BaseDirectory}testcert.key\" -keyform P12 -passin pass:password -outform DER -out \"{FilePath}.sig\" -md sha256",
+                    OpenSslOptions = "cms -sign -in \"{FilePath}\" -signer \"{BaseDirectory}testcert.crt\" -inkey \"{BaseDirectory}testcert.key\" -keyform P12 -passin pass:password -outform DER -out \"{FilePath}.sig\" -md sha256 -binary",
                     OpenSslTimeoutInMs = 30000,
                     OsslSignCodePath = "osslsigncode",
                     TimestampOptions = "add -t \"http://timestamp.digicert.com\" -in \"{FilePath}.sig\" -out \"{FilePath}.timestamped.sig\""


### PR DESCRIPTION
15081

The cms -sign invocation in OpenSslOptions omitted -binary, so openssl ran the content through SMIME_crlf_copy and digested a CRLF-rewritten copy rather than the bytes on disk. This is OpenSSL library behaviour, not host behaviour.

The manifest is only the visible symptom. Text canonicalization also rewrites every lone LF inside a zip, dll or exe before hashing, so detached signatures over binaries have never covered the shipped bytes either. The verify command documented in Readme.md passes -binary and therefore could not have succeeded against these signatures for any real archive. Two things kept that hidden: the client's HasValidDetachedSignature was reduced to a structural check because the canonicalized digest could not be reproduced in .NET, and the one test that did verify byte-exactly fell back to asserting the .sig merely exists and is non-empty whenever validation failed.

Adds -binary to the service and test-harness templates, restores the client check to a real CheckSignature(verifySignatureOnly: true) against the raw bytes, drops the fallback assertion, and adds LF/CRLF cases that fail without the flag. Signatures issued before this change verify only without -binary and ones issued after only with it.